### PR TITLE
add better logging with slog

### DIFF
--- a/host_functions.go
+++ b/host_functions.go
@@ -2,7 +2,6 @@ package wasify
 
 import (
 	"context"
-	"fmt"
 )
 
 const MDK_ENV = "wasify"
@@ -24,12 +23,24 @@ func (hf *hostFunctions) newLog() *HostFunction {
 		Name: "log",
 		Callback: func(ctx context.Context, m ModuleProxy, params Params) *Results {
 
-			fmt.Println(string(params[0].Value))
+			msg := string(params[0].Value)
+			lvl := LogSeverity(params[1].Value[0] - '0')
+
+			switch lvl {
+			case LogDebug:
+				hf.moduleConfig.log.Debug(msg)
+			case LogInfo:
+				hf.moduleConfig.log.Info(msg)
+			case LogWarning:
+				hf.moduleConfig.log.Warn(msg)
+			case LogError:
+				hf.moduleConfig.log.Error(msg)
+			}
 
 			return nil
 
 		},
-		Params:  []ValueType{ValueTypeByte},
+		Params:  []ValueType{ValueTypeByte, ValueTypeByte},
 		Returns: []ValueType{},
 
 		// required fields

--- a/mdk/host_functions.go
+++ b/mdk/host_functions.go
@@ -3,8 +3,28 @@ package mdk
 import "fmt"
 
 //go:wasmimport wasify log
-func log(ArgOffset)
+func log(ArgOffset, ArgOffset)
 
 func Log(format string, a ...any) {
-	log(Arg(fmt.Sprintf(format, a...)))
+	LogDebug(format, a...)
+}
+
+func LogDebug(format string, a ...any) {
+	slog(format, "1", a...)
+}
+
+func LogInfo(format string, a ...any) {
+	slog(format, "2", a...)
+}
+
+func LogWarning(format string, a ...any) {
+	slog(format, "3", a...)
+}
+
+func LogError(format string, a ...any) {
+	slog(format, "4", a...)
+}
+
+func slog(format string, lvl string, a ...any) {
+	log(Arg(fmt.Sprintf(format, a...)), Arg(lvl))
 }


### PR DESCRIPTION
resolves #5 

severity depends on the severity specified during module initialization.

```go
mdk.Log("log") // Log = LogDebug
mdk.LogInfo("log info")
mdk.LogDebug("log debug")
mdk.LogWarning("log warning")
mdk.LogError("log error")
```